### PR TITLE
Use `requre_relative` in `spec_helper`

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require "pkcs7/cryptographer"
-require "pkcs7/cryptographer/entity"
+require_relative "../lib/pkcs7/cryptographer"
+require_relative "../lib/pkcs7/cryptographer/entity"
 require "pry"
 require "timecop"
 


### PR DESCRIPTION
`require` is ambiguous when gem is installed globally.